### PR TITLE
Reorder ?assertEqual arguments

### DIFF
--- a/test/octo_http_helper_test.erl
+++ b/test/octo_http_helper_test.erl
@@ -4,18 +4,18 @@
 
 options_to_query_params_test() ->
   ?assertEqual(
-    octo_http_helper:options_to_query_params([]),
-    ""
+    "",
+    octo_http_helper:options_to_query_params([])
   ),
   ?assertEqual(
-    octo_http_helper:options_to_query_params([{per_page, 100}]),
-    "per_page=100"
+    "per_page=100",
+    octo_http_helper:options_to_query_params([{per_page, 100}])
   ),
   ?assertEqual(
-    octo_http_helper:options_to_query_params([{page, 2}]),
-    "page=2"
+    "page=2",
+    octo_http_helper:options_to_query_params([{page, 2}])
   ),
   ?assertEqual(
-    octo_http_helper:options_to_query_params([{per_page, 100}, {page, 2}]),
-    "per_page=100&page=2"
+    "per_page=100&page=2",
+    octo_http_helper:options_to_query_params([{per_page, 100}, {page, 2}])
   ).

--- a/test/octo_pull_request_test.erl
+++ b/test/octo_pull_request_test.erl
@@ -26,37 +26,37 @@ list_pull_request_files_test() ->
 
 is_pull_request_merged_test() ->
   ?assertEqual(
-    octo:is_pull_request_merged("sdepold", "octo.erl", 1, request_options()),
-    {ok, false}
+    {ok, false},
+    octo:is_pull_request_merged("sdepold", "octo.erl", 1, request_options())
   ),
   ?assertEqual(
-    octo:is_pull_request_merged("sdepold", "octo.erl", 2, request_options()),
-    {ok, true}
+    {ok, true},
+    octo:is_pull_request_merged("sdepold", "octo.erl", 2, request_options())
   ).
 
 create_pull_request_test() ->
   {ok, PullRequest}        = create_test_pull_request(),
   {ok, _ClosedPullRequest} = close_pull_request(PullRequest),
-  ?assertEqual(PullRequest#octo_pull_request.title, <<"Amazing new feature">>),
-  ?assertEqual(PullRequest#octo_pull_request.body, <<"Please pull this in!">>).
+  ?assertEqual(<<"Amazing new feature">>,  PullRequest#octo_pull_request.title),
+  ?assertEqual(<<"Please pull this in!">>, PullRequest#octo_pull_request.body).
 
 update_pull_request_state_test() ->
   {ok, PullRequest}        = create_test_pull_request(),
   {ok, _ClosedPullRequest} = close_pull_request(PullRequest),
   {ok, AllPullRequests}    = octo:list_pull_requests("sdepold", "octo.erl-test", request_options()),
-  ?assertEqual(AllPullRequests, []).
+  ?assertEqual([], AllPullRequests).
 
 update_pull_request_title_test() ->
   {ok, PullRequest}        = create_test_pull_request(),
   {ok, UpdatedPullRequest} = update_pull_request(PullRequest, {{<<"title">>, <<"Something else">>}}),
   {ok, _ClosedPullRequest} = close_pull_request(PullRequest),
-  ?assertEqual(UpdatedPullRequest#octo_pull_request.title, <<"Something else">>).
+  ?assertEqual(<<"Something else">>, UpdatedPullRequest#octo_pull_request.title).
 
 update_pull_request_body_test() ->
   {ok, PullRequest}        = create_test_pull_request(),
   {ok, UpdatedPullRequest} = update_pull_request(PullRequest, {{<<"body">>, <<"Noot">>}}),
   {ok, _ClosedPullRequest} = close_pull_request(PullRequest),
-  ?assertEqual(UpdatedPullRequest#octo_pull_request.body, <<"Noot">>).
+  ?assertEqual(<<"Noot">>, UpdatedPullRequest#octo_pull_request.body).
 
 merge_pull_request_test_() ->
   {
@@ -85,27 +85,41 @@ find_test_pull_request_in_list([ PullRequest = #octo_pull_request{ title = <<"Te
 find_test_pull_request_in_list([ _ | Rest ]) -> find_test_pull_request_in_list(Rest).
 
 assert_pull_request(PullRequest) ->
-  ?assertEqual(PullRequest#octo_pull_request.id,         26701040),
-  ?assertEqual(PullRequest#octo_pull_request.number,     1),
-  ?assertEqual(PullRequest#octo_pull_request.html_url,   <<"https://github.com/sdepold/octo.erl/pull/1">>),
-  ?assertEqual(PullRequest#octo_pull_request.title,      <<"Test">>),
-  ?assertEqual(PullRequest#octo_pull_request.state,      <<"open">>),
-  ?assertEqual(PullRequest#octo_pull_request.body,       <<"Do not close this PR as the tests are reading and checking it.">>),
-  ?assertEqual(PullRequest#octo_pull_request.created_at, <<"2014-12-30T20:02:37Z">>),
-  ?assertEqual(PullRequest#octo_pull_request.updated_at, <<"2015-07-31T04:35:33Z">>).
+  ?assertEqual(26701040,                   PullRequest#octo_pull_request.id),
+  ?assertEqual(1,                          PullRequest#octo_pull_request.number),
+  ?assertEqual(<<"Test">>,                 PullRequest#octo_pull_request.title),
+  ?assertEqual(<<"open">>,                 PullRequest#octo_pull_request.state),
+  ?assertEqual(<<"2014-12-30T20:02:37Z">>, PullRequest#octo_pull_request.created_at),
+  ?assertEqual(<<"2015-07-31T04:35:33Z">>, PullRequest#octo_pull_request.updated_at),
+  ?assertEqual(<<"https://github.com/sdepold/octo.erl/pull/1">>,
+      PullRequest#octo_pull_request.html_url),
+  ?assertEqual(<<"Do not close this PR as the tests are reading and checking it.">>,
+      PullRequest#octo_pull_request.body).
 
 assert_commit(Commit) ->
-  ?assertEqual(Commit#octo_commit.html_url, <<"https://github.com/sdepold/octo.erl/commit/b87ca4769260b778c6f4b6e5dadab546f5c89adc">>),
-  ?assertEqual(Commit#octo_commit.sha,      <<"b87ca4769260b778c6f4b6e5dadab546f5c89adc">>).
+  ?assertEqual(
+    <<"https://github.com/sdepold/octo.erl/commit/b87ca4769260b778c6f4b6e5dadab546f5c89adc">>,
+    Commit#octo_commit.html_url
+  ),
+  ?assertEqual(
+    <<"b87ca4769260b778c6f4b6e5dadab546f5c89adc">>,
+    Commit#octo_commit.sha
+  ).
 
 assert_file(File) ->
-  ?assertEqual(File#octo_file.sha,       <<"345e6aef713208c8d50cdea23b85e6ad831f0449">>),
-  ?assertEqual(File#octo_file.filename,  <<"README.md">>),
-  ?assertEqual(File#octo_file.status,    <<"modified">>),
-  ?assertEqual(File#octo_file.additions, 1),
-  ?assertEqual(File#octo_file.deletions, 12),
-  ?assertEqual(File#octo_file.changes,   13),
-  ?assertEqual(File#octo_file.blob_url,  <<"https://github.com/sdepold/octo.erl/blob/b87ca4769260b778c6f4b6e5dadab546f5c89adc/README.md">>).
+  ?assertEqual(<<"README.md">>, File#octo_file.filename),
+  ?assertEqual(<<"modified">>,  File#octo_file.status),
+  ?assertEqual(1,               File#octo_file.additions),
+  ?assertEqual(12,              File#octo_file.deletions),
+  ?assertEqual(13,              File#octo_file.changes),
+  ?assertEqual(
+    <<"345e6aef713208c8d50cdea23b85e6ad831f0449">>,
+    File#octo_file.sha
+  ),
+  ?assertEqual(
+    <<"https://github.com/sdepold/octo.erl/blob/b87ca4769260b778c6f4b6e5dadab546f5c89adc/README.md">>,
+    File#octo_file.blob_url
+  ).
 
 request_options() ->
   AuthToken = os:getenv("AUTH_TOKEN"),

--- a/test/octo_reference_test.erl
+++ b/test/octo_reference_test.erl
@@ -21,41 +21,41 @@ list_branches_test() ->
   {ok, Branches} = octo:list_branches("sdepold", "octo.erl-test", request_options()),
   RefNames       = [ Branch#octo_reference.ref || Branch <- Branches ],
   ?assertEqual(
-    RefNames,
-    [<<"master">>, <<"test/base">>, <<"test/head">>]
+    [<<"master">>, <<"test/base">>, <<"test/head">>],
+    RefNames
   ).
 
 list_tags_test() ->
   {ok, Tags} = octo:list_tags("sdepold", "octo.erl-test", request_options()),
   RefNames   = [ Tag#octo_reference.ref || Tag <- Tags ],
-  ?assertEqual(RefNames, [<<"omnom">>, <<"test">>]).
+  ?assertEqual([<<"omnom">>, <<"test">>], RefNames).
 
 read_tag_does_not_resolve_branch_names_test() ->
   {err, _} = octo:read_tag("sdepold", "octo.erl-test", "master", request_options()).
 
 read_tag_with_valid_tag_name_test() ->
   {ok, Tag} = octo:read_tag("sdepold", "octo.erl-test", "omnom", request_options()),
-  ?assertEqual(Tag#octo_reference.ref, <<"omnom">>).
+  ?assertEqual(<<"omnom">>, Tag#octo_reference.ref).
 
 read_branch_does_not_resolve_tag_names_test() ->
   {err, _} = octo:read_branch("sdepold", "octo.erl-test", "omnom", request_options()).
 
 read_branch_with_valid_branch_name_test() ->
   {ok, Branch} = octo:read_branch("sdepold", "octo.erl-test", "test/head", request_options()),
-  ?assertEqual(Branch#octo_reference.ref, <<"test/head">>).
+  ?assertEqual(<<"test/head">>, Branch#octo_reference.ref).
 
 read_reference_test_() ->
   {
     timeout, 60, fun () ->
       ExpectedBranchRef = "refs/heads/test/head",
       {ok, Branch} = octo:read_reference("sdepold", "octo.erl-test", "heads/test/head", request_options()),
-      ?assertEqual(Branch#octo_reference.ref, list_to_binary(ExpectedBranchRef)),
+      ?assertEqual(list_to_binary(ExpectedBranchRef), Branch#octo_reference.ref),
       {ok, FullReferencedBranch} = octo:read_reference("sdepold", "octo.erl-test", ExpectedBranchRef, request_options()),
-      ?assertEqual(FullReferencedBranch#octo_reference.ref, list_to_binary(ExpectedBranchRef)),
+      ?assertEqual(list_to_binary(ExpectedBranchRef), FullReferencedBranch#octo_reference.ref),
       {ok, Tag} = octo:read_reference("sdepold", "octo.erl-test", "tags/omnom", request_options()),
-      ?assertEqual(Tag#octo_reference.ref, <<"refs/tags/omnom">>),
+      ?assertEqual(<<"refs/tags/omnom">>, Tag#octo_reference.ref),
       {ok, Pull} = octo:read_reference("sdepold", "octo.erl-test", "pull/1/merge", request_options()),
-      ?assertEqual(Pull#octo_reference.ref, <<"refs/pull/1/merge">>)
+      ?assertEqual(<<"refs/pull/1/merge">>, Pull#octo_reference.ref)
     end
   }.
 
@@ -67,7 +67,7 @@ create_reference_test_() ->
         {<<"sha">>, <<"f5fab067ab146c389f6661046695fb0bbe1608b0">>}
       }, request_options()),
       {ok, _} = octo:delete_reference("sdepold", "octo.erl-test", "heads/test/another-head", request_options()),
-      ?assertEqual(Reference#octo_reference.ref, <<"refs/heads/test/another-head">>)
+      ?assertEqual(<<"refs/heads/test/another-head">>, Reference#octo_reference.ref)
     end
   }.
 
@@ -78,12 +78,12 @@ create_branch_test_() ->
         "sdepold", "octo.erl-test", "test/another-head",
         "f5fab067ab146c389f6661046695fb0bbe1608b0", request_options()
       ),
-      ?assertEqual(Branch#octo_reference.ref, <<"test/another-head">>),
+      ?assertEqual(<<"test/another-head">>, Branch#octo_reference.ref),
       {ok, Branches} = octo:list_branches("sdepold", "octo.erl-test", request_options()),
       RefNames       = [ Branch#octo_reference.ref || Branch <- Branches ],
       ?assertEqual(
-        RefNames,
-        [<<"master">>, <<"test/another-head">>, <<"test/base">>, <<"test/head">>]
+        [<<"master">>, <<"test/another-head">>, <<"test/base">>, <<"test/head">>],
+        RefNames
       ),
       {ok, _} = octo:delete_branch("sdepold", "octo.erl-test", "test/another-head", request_options())
     end
@@ -96,10 +96,10 @@ create_tag_test_() ->
         "sdepold", "octo.erl-test", "another-tag",
         "f5fab067ab146c389f6661046695fb0bbe1608b0", request_options()
       ),
-      ?assertEqual(Tag#octo_reference.ref, <<"another-tag">>),
+      ?assertEqual(<<"another-tag">>, Tag#octo_reference.ref),
       {ok, Tags} = octo:list_tags("sdepold", "octo.erl-test", request_options()),
       RefNames   = [ Tag#octo_reference.ref || Tag <- Tags ],
-      ?assertEqual(RefNames, [<<"another-tag">>, <<"omnom">>, <<"test">>]),
+      ?assertEqual([<<"another-tag">>, <<"omnom">>, <<"test">>], RefNames),
       {ok, _} = octo:delete_tag("sdepold", "octo.erl-test", "another-tag", request_options())
     end
   }.
@@ -114,14 +114,14 @@ update_reference_test_() ->
       {ok, NewMasterBranch}             = octo:create_branch("sdepold", "octo.erl-test", "test/master", binary_to_list(MasterSha), request_options()),
       {{<<"sha">>, NewMasterSha}, _, _} = NewMasterBranch#octo_reference.object,
 
-      ?assertEqual(NewMasterBranch#octo_reference.ref, <<"test/master">>),
-      ?assertEqual(NewMasterSha, MasterSha),
+      ?assertEqual(<<"test/master">>, NewMasterBranch#octo_reference.ref),
+      ?assertEqual(MasterSha, NewMasterSha),
 
       Payload                                  = {{<<"sha">>, TestHeadSha}, {<<"force">>, true}},
       {ok, UpdatedNewMasterBranch}             = octo:update_reference("sdepold", "octo.erl-test", "refs/heads/test/master", Payload, request_options()),
       {{<<"sha">>, UpdatedNewMasterSha}, _, _} = UpdatedNewMasterBranch#octo_reference.object,
 
-      ?assertEqual(UpdatedNewMasterSha, TestHeadSha),
+      ?assertEqual(TestHeadSha, UpdatedNewMasterSha),
 
       {ok, _} = octo:delete_branch("sdepold", "octo.erl-test", "test/master", request_options())
     end


### PR DESCRIPTION
(I thought I'll create this one once testing problems mentioned in #22 get resolved, but apparently @sdepold doesn't have much time at the moment, so I decided to go ahead so that when he does, he can batch-process things. Oh, and rest assured that this code passed testing on my own fork of octo.erl-test.)

`?assertEqual` requires expected value to be the first argument, so that error messages make sense.